### PR TITLE
Optimized addMapping()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ This method returns a promise that will resolve to a `Mapping` object of the for
 }
 ```
 
+An important optimization note: by default, `addMapping()` will try all the protocols sequentially (in order of NAT-PMP, PCP, UPnP). If we're waiting for timeouts, then this method can take up to ~10 seconds to run. This may be too slow for practical purposes. Instead, run `probeProcotolSupport()` at some point before (also can take up to ~10 seconds), which will cache the results, so that `addMapping()` will only try one protocol that has worked before (this will take <2 seconds).
+
 You can also create a port mapping with a specific protocol:
 
 ```
@@ -84,6 +86,8 @@ portControl.deleteMappingPmp(55555);
 portControl.deleteMappingPcp(55556);
 portControl.deleteMappingUpnp(55557);
 ```
+
+Note: all the deletion methods only work if we're tracking the port mapping in PortControl.activeMappings (see below).
 
 ### Get active port mappings
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This method returns a promise that will resolve to a `Mapping` object of the for
 }
 ```
 
-An important optimization note: by default, `addMapping()` will try all the protocols sequentially (in order of NAT-PMP, PCP, UPnP). If we're waiting for timeouts, then this method can take up to ~10 seconds to run. This may be too slow for practical purposes. Instead, run `probeProcotolSupport()` at some point before (also can take up to ~10 seconds), which will cache the results, so that `addMapping()` will only try one protocol that has worked before (this will take <2 seconds).
+_An important optimization note: by default, `addMapping()` will try all the protocols sequentially (in order of NAT-PMP, PCP, UPnP). If we're waiting for timeouts, then this method can take up to ~10 seconds to run. This may be too slow for practical purposes. Instead, run `probeProcotolSupport()` at some point before (also can take up to ~10 seconds), which will cache the results, so that `addMapping()` will only try one protocol that has worked before (this will take <2 seconds)._
 
 You can also create a port mapping with a specific protocol:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This method returns a promise that will resolve to a `Mapping` object of the for
 }
 ```
 
-_An important optimization note: by default, `addMapping()` will try all the protocols sequentially (in order of NAT-PMP, PCP, UPnP). If we're waiting for timeouts, then this method can take up to ~10 seconds to run. This may be too slow for practical purposes. Instead, run `probeProcotolSupport()` at some point before (also can take up to ~10 seconds), which will cache the results, so that `addMapping()` will only try one protocol that has worked before (this will take <2 seconds)._
+_An important optimization note: by default, `addMapping()` will try all the protocols sequentially (in order of NAT-PMP, PCP, UPnP). If we're waiting for timeouts, then this method can take up to ~10 seconds to run. This may be too slow for practical purposes. Instead, run `probeProtocolSupport()` at some point before (also can take up to ~10 seconds), which will cache the results, so that `addMapping()` will only try one protocol that has worked before (this will take <2 seconds)._
 
 You can also create a port mapping with a specific protocol:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-port-control",
   "description": "Opens ports through a NAT with NAT-PMP, PCP, and UPnP",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": "Kenny Song <kenny.ysong@gmail.com>",
   "repository": {
     "type": "git",

--- a/src/demo_chrome_app/page.js
+++ b/src/demo_chrome_app/page.js
@@ -36,6 +36,13 @@ function start(instance) {
     });
   });
 
+  document.getElementById('protocol-support').addEventListener('click', function () {
+    portControl.getProtocolSupportCache().then(function (support) {
+      document.getElementById('result-protocol-support').innerText =
+          JSON.stringify(support, null, 2);
+    });
+  });
+
   document.getElementById('add-PMP').addEventListener('click', function () {
     var intPort = document.getElementById('internal-port-PMP').value;
     var extPort = document.getElementById('external-port-PMP').value;

--- a/src/demo_chrome_app/window.html
+++ b/src/demo_chrome_app/window.html
@@ -46,6 +46,11 @@
 
     <hr>
 
+    <button id="protocol-support">See protocol support cache</button>
+    <pre id="result-protocol-support"></pre>
+
+    <hr>
+
     <h3>NAT-PMP</h3>
     <div>
       Internal Port <input type="text" id="internal-port-PMP" value="50000">

--- a/src/port-control.json
+++ b/src/port-control.json
@@ -87,7 +87,7 @@
 
       "addMappingUpnp": {
         "type": "method",
-        "value": ["number", "number", "number"],
+        "value": ["number", "number", "number", "string"],
         "ret": {"internalIp": "string", "internalPort": "number",
                 "externalIp": "string", "externalPort": "number",
                 "lifetime": "number", "protocol": "string",
@@ -101,6 +101,12 @@
         "ret": "boolean"
       },
 
+      "getUpnpControlUrl": {
+        "type": "method",
+        "value": [],
+        "ret": "string"
+      },
+
       "getActiveMappings": {
         "type": "method",
         "value": [],
@@ -111,6 +117,13 @@
         "type": "method",
         "value": [],
         "ret": ["array", "string"]
+      },
+
+      "getProtocolSupportCache": {
+        "type": "method",
+        "value": [],
+        "ret": {"natPmp": "boolean", "pcp": "boolean",
+                "upnp": "boolean", "upnpControlUrl": "string"}
       },
 
       "getPrivateIps": {


### PR DESCRIPTION
Added a `PortControl.protocolSupportCache` object, which `addMapping()` now uses. UPnP `addMapping()` is optimized to skip SSDP if we pass in a control URL. UPnP `deleteMapping()` is simplified. `PortControl.deleteMapping()` methods now all consistently use the `Mapping.deleter()` method.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/freedomjs/freedom-port-control/4)

<!-- Reviewable:end -->
